### PR TITLE
Fix link to yolo v3

### DIFF
--- a/neural-networks/supported_nns.md
+++ b/neural-networks/supported_nns.md
@@ -62,7 +62,7 @@ https://www.tablesgenerator.com/html_tables
 
 | Architecture          | Backbone             | Pretrained on      | Framework        | Paper        |
 | ------------          | --------             | -------------      | ---------        | ------------ |
-| YOLO V3               |                      | COCO               | DarkNet (C++)    | [arxiv](https://arxiv.org/abs/1703.06870) |
+| YOLO V3               |                      | COCO               | DarkNet (C++)    | [arxiv](https://arxiv.org/abs/1904.04620) |
 | SSD                   | Inception V2         | COCO               | Tensorflow       | [arxiv](https://arxiv.org/abs/1512.02325) |
 |                       | MobileNet V1         | COCO               |                  |                                           |
 |                       | MobileNet V2         | COCO               |                  |                                           |


### PR DESCRIPTION
The Yolo V3 of Object detection was pointing to the same arxiv paper as Mask R-CNN. I've replaced it with the paper I think was intended.