### PR TITLE
Fix renaming a built-in type (bytes)

### DIFF
--- a/data-organization/Annotation-JSON-format/04_Supervisely_Format_objects.md
+++ b/data-organization/Annotation-JSON-format/04_Supervisely_Format_objects.md
@@ -344,8 +344,8 @@ def mask_2_base64(mask):
     img_pil.putpalette([0,0,0,255,255,255])
     bytes_io = io.BytesIO()
     img_pil.save(bytes_io, format='PNG', transparency=0, optimize=0)
-    bytes = bytes_io.getvalue()
-    return base64.b64encode(zlib.compress(bytes)).decode('utf-8')
+    bytes_enc = bytes_io.getvalue()
+    return base64.b64encode(zlib.compress(bytes_enc)).decode('utf-8')
 ```
 
 Example:
@@ -366,8 +366,8 @@ def mask_2_base64(mask):
     img_pil.putpalette([0,0,0,255,255,255])
     bytes_io = io.BytesIO()
     img_pil.save(bytes_io, format='PNG', transparency=0, optimize=0)
-    bytes = bytes_io.getvalue()
-    return base64.b64encode(zlib.compress(bytes)).decode('utf-8')
+    bytes_enc = bytes_io.getvalue()
+    return base64.b64encode(zlib.compress(bytes_enc)).decode('utf-8')
 
 example_np_bool = np.ones((3, 3), dtype=bool)
 example_np_bool[1][1] = False

--- a/data-organization/supervisely-format.md
+++ b/data-organization/supervisely-format.md
@@ -386,6 +386,6 @@ def mask_2_base64(mask):
     img_pil.putpalette([0,0,0,255,255,255])
     bytes_io = io.BytesIO()
     img_pil.save(bytes_io, format='PNG', transparency=0, optimize=0)
-    bytes = bytes_io.getvalue()
-    return base64.b64encode(zlib.compress(bytes)).decode('utf-8')
+    bytes_enc = bytes_io.getvalue()
+    return base64.b64encode(zlib.compress(bytes_enc)).decode('utf-8')
 ```


### PR DESCRIPTION
Some of the example code for decoding masks sets a local mask called bytes. This redefines the built-in type bytes. The proposed changes rename `bytes` to `bytes_enc` to avoid this. Appending `_enc` was chosen because it's used in your plugins repo, see [here](https://github.com/supervisely/supervisely/blob/fa8d9d1084bd5c37b8551a026b0a494eea3ae247/plugins/dtl/legacy_supervisely_lib/figure/figure_bitmap.py#L208).