### PR TITLE
Update deployment instructions for models

### DIFF
--- a/neural-networks/inference-and-deployment/deploy_and_predict_with_supervisely_sdk.md
+++ b/neural-networks/inference-and-deployment/deploy_and_predict_with_supervisely_sdk.md
@@ -305,7 +305,28 @@ Server will shut down automatically after the prediction is done.
 
 Deploying in a Docker Container is similar to deployment as a Server. This example is useful when you need to run your model on a remote machine or in a cloud environment.
 
-Use this `docker run` command to deploy a model in a docker container (RT-DETRv2 example):
+First pull docker image to your local machine
+
+```bash
+docker pull supervisely/rt-detrv2:1.0.31-deploy
+```
+
+Use this `docker run` command to deploy a model in a docker container (RT-DETRv2 example)
+
+For pretrained:
+
+```bash
+docker run \
+  --shm-size=1g \
+  --runtime=nvidia \
+  --env PYTHONPATH=/app \
+  -p 8000:8000 \
+  supervisely/rt-detrv2:1.0.31-deploy \
+  deploy
+  --model "RT-DETRv2-S"
+```
+
+For custom:
 
 ```bash
 docker run \
@@ -313,15 +334,15 @@ docker run \
   --runtime=nvidia \
   --env-file ~/supervisely.env \
   --env PYTHONPATH=/app \
-  -v ".:/app" \
-  -w /app \
+  -v "./47688_RT-DETRv2:/model" \
   -p 8000:8000 \
-  supervisely/rt-detrv2:1.0.11 \
-  python3 supervisely_integration/serve/main.py deploy \
-  --model "/experiments/27_Lemons/392_RT-DETRv2/checkpoints/best.pth"
+  supervisely/rt-detrv2:1.0.31-deploy \
+  deploy \
+  --model "/model/checkpoints/best.pth" \
+  --device "cuda:0"
 ```
 
-Put your path to the checkpoint file in the `--model` argument (it can be both the local path or a remote path in Team Files). This will start FastAPI server and load the model for inference. The server will be available on [http://localhost:8000](http://localhost:8000).
+Set your own path to artifacts directory for `./47688_RT-DETRv2` in `-v` argument and put your path to the checkpoint file in the `--model` argument (it can be both the local path or a remote path in Team Files). This will start FastAPI server and load the model for inference. The server will be available on [http://localhost:8000](http://localhost:8000).
 
 #### docker compose
 
@@ -330,7 +351,7 @@ You can also use `docker-compose.yml` file for convenience:
 ```yaml
 services:
   rtdetrv2:
-    image: supervisely/rt-detrv2:1.0.11
+    image: supervisely/rt-detrv2:1.0.31-deploy
     shm_size: 1g
     runtime: nvidia
     env_file:
@@ -344,7 +365,6 @@ services:
       - "8000:8000"
     expose:
       - "8000"
-    entrypoint: [ "python3", "supervisely_integration/serve/main.py" ]
     command: [ "deploy", "--model", "./models/392_RT-DETRv2/checkpoints/best.pth" ]
 ```
 
@@ -367,8 +387,8 @@ docker run \
   -v ".:/app" \
   -w /app \
   -p 8000:8000 \
-  supervisely/rt-detrv2:1.0.11 \
-  python3 supervisely_integration/serve/main.py deploy \
+  supervisely/rt-detrv2:1.0.31-deploy \
+  deploy \
   --model "RT-DETRv2-S"
 ```
 
@@ -383,8 +403,7 @@ docker run \
   -v ".:/app" \
   -w /app \
   -p 8000:8000 \
-  supervisely/rt-detrv2:1.0.11 \
-  python3 supervisely_integration/serve/main.py \
+  supervisely/rt-detrv2:1.0.31-deploy \
   predict "./image.jpg" \
   --model "RT-DETRv2-S" \
   --device cuda \

--- a/neural-networks/inference-and-deployment/model-api.md
+++ b/neural-networks/inference-and-deployment/model-api.md
@@ -21,9 +21,13 @@ import supervisely as sly
 
 api = sly.Api()
 
+workspace_id = 555 # <- Use your workspace ID
+
 # Deploy your checkpoint trained in Supervisely
 model = api.nn.deploy(
     model="/path/in/team_files/checkpoint.pt",  # Path to your checkpoint in Team Files
+    device="cuda:0",  # or "cpu"
+    workspace_id=workspace_id
 )
 ```
 {% endtab %}
@@ -33,9 +37,12 @@ import supervisely as sly
 
 api = sly.Api()
 
+workspace_id = 555 # <- Use your workspace ID
+
 # Use ONNX checkpoint
 model = api.nn.deploy(
     model="/path/in/team_files/model.onnx",  # Path to ONNX checkpoint in Team Files
+    workspace_id=workspace_id
 )
 ```
 {% endtab %}
@@ -45,9 +52,12 @@ import supervisely as sly
 
 api = sly.Api()
 
+workspace_id = 555 # <- Use your workspace ID
+
 # Use TensorRT checkpoint
 model = api.nn.deploy(
     model="/path/in/team_files/model.engine",  # Path to TensorRT checkpoint in Team Files
+    workspace_id=workspace_id
 )
 ```
 {% endtab %}
@@ -57,10 +67,13 @@ import supervisely as sly
 
 api = sly.Api()
 
+workspace_id = 555 # <- Use your workspace ID
+
 # Using pytorch checkpoint and convert to TensorRT
 model = api.nn.deploy(
     model="/path/in/team_files/checkpoint.pt",  # Path to your checkpoint in Team Files
     runtime="tensorrt",  # Will convert the model to TensorRT, this will take some time
+    workspace_id=workspace_id
 )
 ```
 {% endtab %}
@@ -79,9 +92,12 @@ import supervisely as sly
 
 api = sly.Api()
 
+workspace_id = 555 # <- Use your workspace ID
+
 # Deploy a pretrained model
 model = api.nn.deploy(
     model="rt-detrv2/rt-detrv2-s"  # Model name from a table of pretrained models in the Serving App
+    workspace_id=workspace_id
 )
 ```
 {% endtab %}
@@ -91,10 +107,13 @@ import supervisely as sly
 
 api = sly.Api()
 
+workspace_id = 555 # <- Use your workspace ID
+
 # ONNX Runtime
 model = api.nn.deploy(
     model="rt-detrv2/rt-detrv2-s"  # Model name from a table of pretrained models in the Serving App
     runtime="onnx",            # Will convert the model to ONNX before deploying
+    workspace_id=workspace_id
 )
 ```
 {% endtab %}
@@ -104,10 +123,13 @@ import supervisely as sly
 
 api = sly.Api()
 
+workspace_id = 555 # <- Use your workspace ID
+
 # TensorRT
 model = api.nn.deploy(
     model="rt-detrv2/rt-detrv2-s"  # Model name from a table of pretrained models in the Serving App
     runtime="tensorrt",        # Will convert the model to TensorRT before deploying
+    workspace_id=workspace_id
 )
 ```
 {% endtab %}
@@ -122,6 +144,7 @@ You can specify additional arguments for the `api.nn.deploy()` method, such as `
 | `model` | `str` | Can be a path to your checkpoint in Team Files or a pretrained model name in the format `framework/model_name` (e.g., `"rt-detrv2/rt-detrv2-s"`). For a custom checkpoint, the checkpoint can be in PyTorch format (`.pt` or `.pth`), ONNX format (`.onnx`), or TensorRT format (`.engine`). For a pretrained model, the framework name is the name of the corresponding Serving App in Supervisely, and the model name is the name of a pretrained model from the models table in the Serving App. |
 | `device` | `str` | Device to run the model on, e.g., `"cuda:0"` or `"cpu"`. If not specified, will automatically use `cuda` device, if available on the agent, otherwise `cpu` will be used. |
 | `runtime` | `str` | Runtime to convert the model to before deploying. Options: `"onnx"`, `"tensorrt"`. Used for pretrained checkpoints. |
+| `workspace_id` | `int` | Workspace where serving app will be deployed. |
 | `agent_id` | `int` | ID of the Supervisely Agent, a machine that is connected to Supervisely where the model will be deployed. If not specified, the agent will be selected automatically depending on GPU usage. |
 
 

--- a/neural-networks/inference-and-deployment/overview.md
+++ b/neural-networks/inference-and-deployment/overview.md
@@ -28,10 +28,13 @@ import supervisely as sly
 
 api = sly.Api()
 
+workspace_id = 555 # <- Use your workspace ID
+
 # 1. Deploy your model
 model = api.nn.deploy(
     model="/path/in/team_files/checkpoint.pt",  # path to your checkpoint in Team Files
     device="cuda:0",  # or "cpu"
+    workspace_id=workspace_id
 )
 
 # 2. Predict

--- a/neural-networks/inference-and-deployment/prediction-api.md
+++ b/neural-networks/inference-and-deployment/prediction-api.md
@@ -19,8 +19,11 @@ import supervisely as sly
 
 api = sly.Api()
 
+workspace_id = 555 # <- Use your workspace ID
+
 model = api.nn.deploy(
     model="/path/in/team_files/checkpoint.pt",  # path to your checkpoint in Team Files
+    workspace_id=workspace_id
 )
 ```
 {% endtab %}
@@ -30,8 +33,11 @@ import supervisely as sly
 
 api = sly.Api()
 
+workspace_id = 555 # <- Use your workspace ID
+
 model = api.nn.deploy(
-    model="rt-detrv2/rt-detrv2-s"  # model identifier in the format "framework/model_name"
+    model="rt-detrv2/rt-detrv2-s",  # model identifier in the format "framework/model_name"
+    workspace_id=workspace_id
 )
 ```
 {% endtab %}
@@ -465,10 +471,13 @@ from supervisely.nn.tracking import track
 import boxmot
 from pathlib import Path
 
+workspace_id = 555 # <- Use your workspace ID
+
 # Deploy a detector
 detector = api.nn.deploy(
     model="rt-detrv2/RT-DETRv2-M",
     device="cuda:0",  # Use GPU for detection
+    workspace_id=workspace_id
 )
 
 # Load BoxMot tracker
@@ -503,10 +512,13 @@ import boxmot
 from supervisely.nn.tracking import to_boxmot
 from pathlib import Path
 
+workspace_id = 555 # <- Use your workspace ID
+
 # Deploy a detector
 model = api.nn.deploy(
     model="rt-detrv2/RT-DETRv2-M",
     device="cuda:0",  # Use GPU for detection
+    workspace_id=workspace_id
 )
 
 # Start predict objects in video


### PR DESCRIPTION
- Added steps to pull the Docker image and updated the Docker run commands to use the latest version (1.0.31-deploy).
- Included workspace_id parameter in the model deployment examples across various API documentation files.
- Clarified the usage of the `--model` argument for both pretrained and custom models in Docker commands.