### PR TITLE
docs(storage): document Azure Entra ID setup

### DIFF
--- a/data-organization/import/import/import-from-cloud.md
+++ b/data-organization/import/import/import-from-cloud.md
@@ -62,8 +62,41 @@ The new connection appears in the table with scope **Team**.
 | Field | Description |
 | --- | --- |
 | Storage account name | Your Azure storage account name. |
-| Secret key or SAS token | Either the account's secret key (looks like `aflmg+wg23fWA+6gAafWmgF4a...`) or a SAS token (looks like `sp=r&st=2026-05-27T10:50:57Z&se=...`). |
+| Authentication | Choose **Access key or SAS token** for shared-key authentication, or **Entra ID** for a Microsoft Entra service principal. |
+| Secret key or SAS token | With **Access key or SAS token**, enter either the account access key or a SAS token. |
+| Tenant ID | With **Entra ID**, enter the Microsoft Entra tenant (directory) ID. |
+| Client ID | With **Entra ID**, enter the service principal's application (client) ID. |
+| Client secret | With **Entra ID**, enter the secret value created for the service principal. Do not enter the secret ID. |
 | Endpoint | **Auto** derives the endpoint from the account name, or switch to **Manual** to set a custom one (e.g. Azurite or another Azure-compatible endpoint). |
+
+##### Authenticate with Microsoft Entra ID
+
+Entra ID authentication lets an Azure administrator disable storage account key access without interrupting Supervisely. Supervisely authenticates as a service principal, so the credentials remain separate from an individual user's Azure account.
+
+1. Sign in to Azure CLI and select the subscription that contains the storage account:
+
+   ```bash
+   az login
+   az account set --subscription <subscription-id>
+   ```
+
+2. Create a service principal and grant it the **Storage Blob Data Contributor** role at the storage account scope:
+
+   ```bash
+   az ad sp create-for-rbac \
+     --name supervisely-remote-storage \
+     --role "Storage Blob Data Contributor" \
+     --scopes /subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Storage/storageAccounts/<storage-account-name>
+   ```
+
+   This role lets Supervisely list containers and read, create, update, and delete blobs. Azure permissions can take several minutes to propagate after the role assignment.
+
+3. Store the command output in your secret manager. Map `tenant` to **Tenant ID**, `appId` to **Client ID**, and `password` to **Client secret**. Azure displays the client secret value only when it is created.
+4. In Supervisely, set **Storage account name**, select **Entra ID** under **Authentication**, fill in all three Entra fields, and click **ADD**. Use **Test** from the connection's **⋮** menu to verify access.
+
+{% hint style="warning" %}
+Treat the client secret like a password. Do not paste it into tickets, logs, or source control; rotate it in Microsoft Entra ID before it expires.
+{% endhint %}
 
 #### Restricting buckets and users
 

--- a/enterprise/post-installation/README.md
+++ b/enterprise/post-installation/README.md
@@ -441,7 +441,8 @@ Cloud credentials allow Supervisely to connect to external cloud services or rem
 3. **Azure Example**:
    * Add:
      * **Storage Account Name**: The name of your Azure Storage account.
-     * **Access Key**: The key to authenticate access to Azure Storage.
+     * **Authentication**: Choose an account access key or SAS token, or authenticate with a Microsoft Entra service principal.
+     * **Entra ID Credentials**: Provide the tenant ID, client ID, and client secret. The service principal needs the **Storage Blob Data Contributor** role on the storage account. See [Authenticate with Microsoft Entra ID](../../data-organization/import/import/import-from-cloud.md#authenticate-with-microsoft-entra-id) for setup instructions.
 4. **Server File System Example**:
    * Specify:
      * **Server Address**: The IP or hostname of the server.

--- a/enterprise/s3/README.md
+++ b/enterprise/s3/README.md
@@ -278,8 +278,11 @@ my-boats-datasets:
   provider: azure
   endpoint: https://<account name>.blob.core.windows.net
   access_key: <account name>
-  secret_key: <secret key 88 chars long or so: aflmg+wg23fWA+6gAafWmgF4a>
-  secret_key: or you can also use SAS token here: ?sv=2019-12-12&ss=bfqt&srt=sco&sp=rwdlacupx&se=2020-10-10T00:00:00Z&st=2020-10-10T00:00:00Z&spr=https&sig=...
+  # Choose one authentication method:
+  secret_key: <account access key or SAS token>
+  # tenant_id: <Microsoft Entra tenant ID>
+  # client_id: <service principal application (client) ID>
+  # client_secret: <service principal client secret value>
   # array of buckets
   buckets:
   - boats_bucket_2020_20_10
@@ -295,6 +298,8 @@ my-planes-datasets:
   - planes_bucket_2020_20_10
   - another_planes_bucket_2020_10_10
 ```
+
+For Microsoft Entra ID authentication, omit `secret_key` and provide `tenant_id`, `client_id`, and `client_secret` together. The service principal needs the **Storage Blob Data Contributor** role on the storage account. See [Authenticate with Microsoft Entra ID](../../data-organization/import/import/import-from-cloud.md#authenticate-with-microsoft-entra-id) for the Azure CLI setup and field mapping.
 
 Links file structure:
 


### PR DESCRIPTION
## What changed

- Document the Entra ID authentication fields in the Azure remote-storage form.
- Add Azure CLI steps for creating a service principal and assigning Storage Blob Data Contributor at storage-account scope.
- Document the equivalent YAML fields and client-secret handling.
- Update the enterprise post-installation overview.

## Why

Supervisely adds service-principal authentication for Azure Blob Storage so deployments can disable shared-key access.

## Validation

- git diff --check
- Relative links and anchors checked.
- Azure CLI options checked.