### PR TITLE
docs: configure the CA bundle, remote links and replicas on `api` alone

### DIFF
--- a/enterprise/http-proxy/README.md
+++ b/enterprise/http-proxy/README.md
@@ -90,27 +90,19 @@ services:
       NODE_EXTRA_CA_CERTS: '/usr/local/share/ca-certificates/'
     volumes:
       - /usr/local/share/ca-certificates/:/usr/local/share/ca-certificates/:ro
-  api-public:
-    environment:
-      NODE_EXTRA_CA_CERTS: '/usr/local/share/ca-certificates/'
-    volumes:
-      - /usr/local/share/ca-certificates/:/usr/local/share/ca-certificates/:ro
-  http-storage:
-    environment:
-      NODE_EXTRA_CA_CERTS: '/usr/local/share/ca-certificates/'
-    volumes:
-      - /usr/local/share/ca-certificates/:/usr/local/share/ca-certificates/:ro
-  migrator:
-    environment:
-      NODE_EXTRA_CA_CERTS: '/usr/local/share/ca-certificates/'
-    volumes:
-      - /usr/local/share/ca-certificates/:/usr/local/share/ca-certificates/:ro
   worker-general:
     environment:
       NODE_EXTRA_CA_CERTS: '/usr/local/share/ca-certificates/'
     volumes:
       - /usr/local/share/ca-certificates/:/usr/local/share/ca-certificates/:ro
 ```
+
+{% hint style="info" %}
+`api` covers the database migrations too: they run as the `api` service, so whatever you configure
+here applies to them. Older versions needed the same block repeated on `api-public`,
+`http-storage` and `migrator` — those services no longer exist. If your override file still names
+them, `supervisely upgrade` offers to merge those sections into `api` for you.
+{% endhint %}
 
 3. Deploy the changes:
 

--- a/enterprise/s3/README.md
+++ b/enterprise/s3/README.md
@@ -103,7 +103,7 @@ Now create `docker-compose.override.yml` under `cd $(sudo supervisely where)`:
 
 ```yaml
 services:
-  http-storage:
+  api:
     volumes:
       - <path to the secret file>:/gcs.json:ro
 ```
@@ -319,7 +319,7 @@ Create a new file `docker-compose.override.yml` under `cd $(sudo supervisely whe
 
 ```yaml
 services:
-  http-storage:
+  api:
     volumes:
       - <path to the configuration file>:/remote_links.yml:ro
 ```
@@ -327,14 +327,20 @@ services:
 Then execute the following to apply the changes:
 
 ```
-sudo supervisely up -d http-storage
+sudo supervisely up -d api
 ```
+
+{% hint style="info" %}
+`api` serves the storage and runs the migrations, so this one section covers both. Older versions
+had a separate `http-storage` service and the bind went there; if your override file still names
+it, `supervisely upgrade` offers to merge that section into `api` for you.
+{% endhint %}
 
 Google Cloud Storage secret file example, `docker-compose.override.yml`:
 
 ```yaml
 services:
-  http-storage:
+  api:
     volumes:
       - <path to the secret file>:/secret_planes.json:ro
 ```

--- a/enterprise/scalability-tuning/README.md
+++ b/enterprise/scalability-tuning/README.md
@@ -12,7 +12,7 @@ For high-load environments, you can increase the number of replicas for certain 
 
 ### Creating a docker-compose.override.yml
 
-To increase the number of replicas for the `api` and `api-public` services, create a `docker-compose.override.yml` file in the Supervisely installation directory:
+To increase the number of replicas for the `api` service, create a `docker-compose.override.yml` file in the Supervisely installation directory:
 
 ```bash
 cd $(sudo supervisely where)
@@ -27,13 +27,13 @@ services:
       POSTGRES_POOL_MAX: '20'
     deploy:
       replicas: 3
-
-  api-public:
-    environment:
-      POSTGRES_POOL_MAX: '20'
-    deploy:
-      replicas: 3
 ```
+
+{% hint style="info" %}
+One service, not two: `api` is what the `api-public` service was renamed to, and it also serves
+the browser API, the storage and the frame renderers. If your override file still has an
+`api-public` section, `supervisely upgrade` offers to merge it into `api` for you.
+{% endhint %}
 
 The values provided above are just examples. You can adjust the number of replicas and pool size based on your server's load.\
 If you notice "Timeout acquiring a connection. The pool is probably full" in the logs, you may need to increase the `POSTGRES_POOL_MAX` / replicas value.
@@ -44,7 +44,7 @@ After creating or modifying this file, apply the changes by redeploying the serv
 sudo supervisely up -d
 ```
 
-This configuration will start 3 replicas each of the `api` and `api-public` services, which will improve the stability and performance of the Supervisely platform.
+This configuration will start 3 replicas of the `api` service, which will improve the stability and performance of the Supervisely platform.
 
 `POSTGRES_POOL_MAX` is the maximum number of connections to the PostgreSQL database that each service can use. You can adjust this value based on your server's available resources.
 
@@ -66,10 +66,10 @@ or:
 
 The endpoint above is only an example. The same issue may appear on other API endpoints that need to aggregate or read a large amount of data.
 
-To confirm that the error is caused by a database query timeout, check the `api-public` logs:
+To confirm that the error is caused by a database query timeout, check the `api` logs:
 
 ```bash
-sudo supervisely logs api-public
+sudo supervisely logs api
 ```
 
 You may see messages similar to:
@@ -91,7 +91,7 @@ Add the following configuration:
 
 ```yaml
 services:
-  api-public:
+  api:
     environment:
       POSTGRES_STATEMENT_TIMEOUT: '300000'
       POSTGRES_QUERY_TIMEOUT: '300000'


### PR DESCRIPTION
The services these pages tell customers to configure no longer exist: `api-public` is called `api`, `http-storage` and `image-converter` were absorbed into it, and the compose `migrator` service is being dropped (supervisely/main!1966) — the migrations run as `api`, so what you set for `api` reaches them.

- **enterprise/http-proxy** — `NODE_EXTRA_CA_CERTS` + the CA mount on two services (`api`, `worker-general`) instead of five. The repetition was the whole point of the old advice and is now actively wrong: an override section naming a service the bundle does not ship makes compose refuse the entire project, so every `supervisely` command stops working.
- **enterprise/s3** — the `/remote_links.yml` bind, the GCS credentials file and the secret-file example move from `http-storage` to `api`, and `supervisely up -d http-storage` with them.
- **enterprise/scalability-tuning** — one `api` section instead of `api` plus `api-public` (the same service twice), and `supervisely logs api`.

Each page keeps a short note for an instance that still has the old sections: `supervisely upgrade` offers to merge them into `api`.

CLI side: supervisely/enterprise-cli!11.
